### PR TITLE
fix: change return structure to a standard and change default options

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,14 @@ Available options:
 
 | Name   | Description   | Type     | Default |
 | ------ | ------------- | -------- | ------- |
-| import | Options to pass to [postcss-import](https://github.com/postcss/postcss-import#path) | Object | undefined |
-| mixins | Options to pass to [postcss-mixins](https://github.com/postcss/postcss-mixins#mixinsdir) | Object | undefined |
-| advancedVariables | Options to pass to [postcss-advanced-variables](https://github.com/jonathantneal/postcss-advanced-variables#options) | Object | undefined |
+| import | Options to pass to [postcss-import](https://github.com/postcss/postcss-import#path) | Object | `{}` 
+| mixins | Options to pass to [postcss-mixins](https://github.com/postcss/postcss-mixins#mixinsdir) | Object | `{ mixinsDir: './src/styles/mixins' }` |
+| advancedVariables | Options to pass to [postcss-advanced-variables](https://github.com/jonathantneal/postcss-advanced-variables#options) | Object | `{}`¹ |
 | cssVariables | Options to pass to [postcss-css-variables](https://github.com/MadLittleMods/postcss-css-variables), false disables the plugin | Object/boolean | `{ preserveAtRulesOrder: true }` |
 | url | Options to pass to [postcss-url](https://github.com/postcss/postcss-url), false disables any transpilation of `url()` declarations | Array/Object/boolean | `{ url: 'rebase' }` |
 | browsers | Supported browsers list to pass to [postcss-cssnext](https://github.com/MoOx/postcss-cssnext) | Array | [browserslist-config-google](https://github.com/awkaiser/browserslist-config-google) |
+
+1) `advancedVariables` is not actually empty by default since it contains `{disable: '@mixin, @include, @content, @import'}` but this options can be easily changed by passing the desired `disable` object.
 
 The [postcss-url](https://github.com/postcss/postcss-url) plugin is enabled by default. You may disable it like so:
 

--- a/index.js
+++ b/index.js
@@ -2,9 +2,9 @@
 
 module.exports = (options = {}) => {
     options = {
-        import: undefined,
+        import: {},
         mixins: { mixinsDir: './src/styles/mixins' },
-        advancedVariables: { ...options.advancedVariables, disable: '@mixin, @include, @content, @import' }, // Ignore @mixin, @include, @content and @import at-rules
+        advancedVariables: { disable: '@mixin, @include, @content, @import', ...options.advancedVariables }, // Ignore @mixin, @include, @content and @import at-rules
         browsers: ['extends browserslist-config-google'],
         cssVariables: { preserveAtRulesOrder: true },
         url: { url: 'rebase' },
@@ -12,18 +12,18 @@ module.exports = (options = {}) => {
     };
 
     return {
-        plugins: [
+        plugins: {
             // Let postcss parse @import statements
-            require('postcss-import')(options.import),
+            [require.resolve('postcss-import')]: options.import,
             // Process url() statements
-            options.url && require('postcss-url')(options.url),
+            ...(options.url ? { [require.resolve('postcss-url')]: options.url } : {}),
             // Add support for CSS mixins
-            require('postcss-mixins')(options.mixins),
+            [require.resolve('postcss-mixins')]: options.mixins,
             // Add support for iterators (@for and @each) and conditionals (@if and @else)
-            require('postcss-advanced-variables')(options.advancedVariables),
+            [require.resolve('postcss-advanced-variables')]: options.advancedVariables,
             // Use postcss-preset-env to enable plugins to transform official CSS features
             // to be compatible in older browsers
-            require('postcss-preset-env')({
+            [require.resolve('postcss-preset-env')]: {
                 browsers: options.browsers,
                 stage: 3,
                 // Disable preserve so that the outputed CSS is consistent among all browsers,
@@ -45,11 +45,11 @@ module.exports = (options = {}) => {
                     // See: https://github.com/csstools/postcss-preset-env/issues/133
                     overrideBrowserslist: options.browsers,
                 },
-            }),
+            },
             // Add support for `alpha()` and other color utilities
-            require('postcss-color-function')(),
+            [require.resolve('postcss-color-function')]: {},
             // Lets you reduce calc() references whenever it's possible
-            require('postcss-calc')(),
-        ].filter(Boolean),
+            [require.resolve('postcss-calc')]: {},
+        },
     };
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const { baseConfig } = require('@moxy/jest-config');
+
+module.exports = baseConfig();

--- a/package-lock.json
+++ b/package-lock.json
@@ -150,6 +150,23 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/runtime": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.3.tgz",
+      "integrity": "sha512-fVHx1rzEmwB130VTkLnxR+HmxcTjGzH12LYQcFFoBwakMd3aOMD4OsRN7tGG/UOYE2ektgFrS8uACAoRk1CY0w==",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.13.2"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.13.3",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+          "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+          "dev": true
+        }
+      }
+    },
     "@babel/template": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
@@ -675,6 +692,20 @@
         "eslint-plugin-react-hooks": "^2.3.0"
       }
     },
+    "@moxy/jest-config": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@moxy/jest-config/-/jest-config-1.2.0.tgz",
+      "integrity": "sha512-gXK3jjaCPpyMnY4X4JD12Dxe7GywG6eB0ZVH2S+YEQVkiPDPUxYWjXpw4HOhBENNeu9jqf0xLbilfBtg5CdMRw==",
+      "dev": true,
+      "requires": {
+        "@testing-library/jest-dom": "^4.2.0",
+        "babel-jest": "^24.9.0",
+        "ci-info": "^2.0.0",
+        "identity-obj-proxy": "^3.0.0",
+        "jest-serializer-path": "^0.1.15",
+        "mime": "^2.4.4"
+      }
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -724,6 +755,50 @@
       "dev": true,
       "requires": {
         "any-observable": "^0.3.0"
+      }
+    },
+    "@testing-library/jest-dom": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-4.2.4.tgz",
+      "integrity": "sha512-j31Bn0rQo12fhCWOUWy9fl7wtqkp7In/YP2p5ZFyRuiiB9Qs3g+hS4gAmDWONbAHcRmVooNJ5eOHQDCOmUFXHg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.5.1",
+        "chalk": "^2.4.1",
+        "css": "^2.2.3",
+        "css.escape": "^1.5.1",
+        "jest-diff": "^24.0.0",
+        "jest-matcher-utils": "^24.0.0",
+        "lodash": "^4.17.11",
+        "pretty-format": "^24.0.0",
+        "redent": "^3.0.0"
+      },
+      "dependencies": {
+        "indent-string": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+          "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+          "dev": true
+        },
+        "redent": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+          "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+          "dev": true,
+          "requires": {
+            "indent-string": "^4.0.0",
+            "strip-indent": "^3.0.0"
+          }
+        },
+        "strip-indent": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+          "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+          "dev": true,
+          "requires": {
+            "min-indent": "^1.0.0"
+          }
+        }
       }
     },
     "@types/babel__core": {
@@ -2366,6 +2441,18 @@
         }
       }
     },
+    "css": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
+      "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.3",
+        "source-map": "^0.6.1",
+        "source-map-resolve": "^0.5.2",
+        "urix": "^0.1.0"
+      }
+    },
     "css-blank-pseudo": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/css-blank-pseudo/-/css-blank-pseudo-0.1.4.tgz",
@@ -2406,6 +2493,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.1.tgz",
       "integrity": "sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY="
+    },
+    "css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
+      "dev": true
     },
     "cssdb": {
       "version": "4.4.0",
@@ -4553,6 +4646,12 @@
         "har-schema": "^2.0.0"
       }
     },
+    "harmony-reflect": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.1.tgz",
+      "integrity": "sha512-WJTeyp0JzGtHcuMsi7rw2VwtkvLa+JyfEKJCFyfcS0+CDkjQ5lHPu7zEhFZP+PDSRrEgXa5Ah0l1MbgbE41XjA==",
+      "dev": true
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -4709,6 +4808,15 @@
       "dev": true,
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "identity-obj-proxy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
+      "integrity": "sha1-lNK9qWCERT7zb7xarsN+D3nx/BQ=",
+      "dev": true,
+      "requires": {
+        "harmony-reflect": "^1.4.6"
       }
     },
     "ignore": {
@@ -6570,6 +6678,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true
+    },
+    "min-indent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.0.tgz",
+      "integrity": "sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY=",
       "dev": true
     },
     "minimatch": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "scripts": {
     "lint": "eslint .",
-    "test": "jest --env node --coverage",
+    "test": "jest",
     "prerelease": "npm t && npm run lint",
     "release": "standard-version",
     "postrelease": "git push --follow-tags origin HEAD && npm publish"
@@ -59,6 +59,7 @@
     "@commitlint/cli": "^8.0.0",
     "@commitlint/config-conventional": "^8.0.0",
     "@moxy/eslint-config": "^9.1.2",
+    "@moxy/jest-config": "^1.2.0",
     "eslint": "^6.5.1",
     "husky": "^3.0.9",
     "jest": "^24.5.0",

--- a/test/__snapshots__/unit.spec.js.snap
+++ b/test/__snapshots__/unit.spec.js.snap
@@ -4,28 +4,29 @@ exports[`should disable postcss-css-variables if options.cssVariables is false 1
 Object {
   "plugins": Array [
     Array [
-      "postcss-import",
+      "<PROJECT_ROOT>/node_modules/postcss-import/index.js",
+      Object {},
     ],
     Array [
-      "postcss-url",
+      "<PROJECT_ROOT>/node_modules/postcss-url/src/index.js",
       Object {
         "url": "rebase",
       },
     ],
     Array [
-      "postcss-mixins",
+      "<PROJECT_ROOT>/node_modules/postcss-mixins/index.js",
       Object {
         "mixinsDir": "./src/styles/mixins",
       },
     ],
     Array [
-      "postcss-advanced-variables",
+      "<PROJECT_ROOT>/node_modules/postcss-advanced-variables/index.js",
       Object {
         "disable": "@mixin, @include, @content, @import",
       },
     ],
     Array [
-      "postcss-preset-env",
+      "<PROJECT_ROOT>/node_modules/postcss-preset-env/index.js",
       Object {
         "autoprefixer": Object {
           "overrideBrowserslist": Array [
@@ -47,10 +48,12 @@ Object {
       },
     ],
     Array [
-      "postcss-color-function",
+      "<PROJECT_ROOT>/node_modules/postcss-color-function/index.js",
+      Object {},
     ],
     Array [
-      "postcss-calc",
+      "<PROJECT_ROOT>/node_modules/postcss-calc/dist/index.js",
+      Object {},
     ],
   ],
 }
@@ -60,22 +63,23 @@ exports[`should disable postcss-url if options.url is false 1`] = `
 Object {
   "plugins": Array [
     Array [
-      "postcss-import",
+      "<PROJECT_ROOT>/node_modules/postcss-import/index.js",
+      Object {},
     ],
     Array [
-      "postcss-mixins",
+      "<PROJECT_ROOT>/node_modules/postcss-mixins/index.js",
       Object {
         "mixinsDir": "./src/styles/mixins",
       },
     ],
     Array [
-      "postcss-advanced-variables",
+      "<PROJECT_ROOT>/node_modules/postcss-advanced-variables/index.js",
       Object {
         "disable": "@mixin, @include, @content, @import",
       },
     ],
     Array [
-      "postcss-preset-env",
+      "<PROJECT_ROOT>/node_modules/postcss-preset-env/index.js",
       Object {
         "autoprefixer": Object {
           "overrideBrowserslist": Array [
@@ -99,10 +103,12 @@ Object {
       },
     ],
     Array [
-      "postcss-color-function",
+      "<PROJECT_ROOT>/node_modules/postcss-color-function/index.js",
+      Object {},
     ],
     Array [
-      "postcss-calc",
+      "<PROJECT_ROOT>/node_modules/postcss-calc/dist/index.js",
+      Object {},
     ],
   ],
 }
@@ -112,28 +118,29 @@ exports[`should have a good base config 1`] = `
 Object {
   "plugins": Array [
     Array [
-      "postcss-import",
+      "<PROJECT_ROOT>/node_modules/postcss-import/index.js",
+      Object {},
     ],
     Array [
-      "postcss-url",
+      "<PROJECT_ROOT>/node_modules/postcss-url/src/index.js",
       Object {
         "url": "rebase",
       },
     ],
     Array [
-      "postcss-mixins",
+      "<PROJECT_ROOT>/node_modules/postcss-mixins/index.js",
       Object {
         "mixinsDir": "./src/styles/mixins",
       },
     ],
     Array [
-      "postcss-advanced-variables",
+      "<PROJECT_ROOT>/node_modules/postcss-advanced-variables/index.js",
       Object {
         "disable": "@mixin, @include, @content, @import",
       },
     ],
     Array [
-      "postcss-preset-env",
+      "<PROJECT_ROOT>/node_modules/postcss-preset-env/index.js",
       Object {
         "autoprefixer": Object {
           "overrideBrowserslist": Array [
@@ -157,10 +164,12 @@ Object {
       },
     ],
     Array [
-      "postcss-color-function",
+      "<PROJECT_ROOT>/node_modules/postcss-color-function/index.js",
+      Object {},
     ],
     Array [
-      "postcss-calc",
+      "<PROJECT_ROOT>/node_modules/postcss-calc/dist/index.js",
+      Object {},
     ],
   ],
 }
@@ -170,26 +179,27 @@ exports[`should pass options.advancedVariables to postcss-advanced-variables  1`
 Object {
   "plugins": Array [
     Array [
-      "postcss-import",
+      "<PROJECT_ROOT>/node_modules/postcss-import/index.js",
+      Object {},
     ],
     Array [
-      "postcss-url",
+      "<PROJECT_ROOT>/node_modules/postcss-url/src/index.js",
       Object {
         "url": "rebase",
       },
     ],
     Array [
-      "postcss-mixins",
+      "<PROJECT_ROOT>/node_modules/postcss-mixins/index.js",
       Object {
         "mixinsDir": "./src/styles/mixins",
       },
     ],
     Array [
-      "postcss-advanced-variables",
+      "<PROJECT_ROOT>/node_modules/postcss-advanced-variables/index.js",
       "foo",
     ],
     Array [
-      "postcss-preset-env",
+      "<PROJECT_ROOT>/node_modules/postcss-preset-env/index.js",
       Object {
         "autoprefixer": Object {
           "overrideBrowserslist": Array [
@@ -213,10 +223,12 @@ Object {
       },
     ],
     Array [
-      "postcss-color-function",
+      "<PROJECT_ROOT>/node_modules/postcss-color-function/index.js",
+      Object {},
     ],
     Array [
-      "postcss-calc",
+      "<PROJECT_ROOT>/node_modules/postcss-calc/dist/index.js",
+      Object {},
     ],
   ],
 }
@@ -226,28 +238,29 @@ exports[`should pass options.browsers to postcss-preset-env  1`] = `
 Object {
   "plugins": Array [
     Array [
-      "postcss-import",
+      "<PROJECT_ROOT>/node_modules/postcss-import/index.js",
+      Object {},
     ],
     Array [
-      "postcss-url",
+      "<PROJECT_ROOT>/node_modules/postcss-url/src/index.js",
       Object {
         "url": "rebase",
       },
     ],
     Array [
-      "postcss-mixins",
+      "<PROJECT_ROOT>/node_modules/postcss-mixins/index.js",
       Object {
         "mixinsDir": "./src/styles/mixins",
       },
     ],
     Array [
-      "postcss-advanced-variables",
+      "<PROJECT_ROOT>/node_modules/postcss-advanced-variables/index.js",
       Object {
         "disable": "@mixin, @include, @content, @import",
       },
     ],
     Array [
-      "postcss-preset-env",
+      "<PROJECT_ROOT>/node_modules/postcss-preset-env/index.js",
       Object {
         "autoprefixer": Object {
           "overrideBrowserslist": "foo",
@@ -267,10 +280,12 @@ Object {
       },
     ],
     Array [
-      "postcss-color-function",
+      "<PROJECT_ROOT>/node_modules/postcss-color-function/index.js",
+      Object {},
     ],
     Array [
-      "postcss-calc",
+      "<PROJECT_ROOT>/node_modules/postcss-calc/dist/index.js",
+      Object {},
     ],
   ],
 }
@@ -280,28 +295,29 @@ exports[`should pass options.cssVariables to postcss-css-variables 1`] = `
 Object {
   "plugins": Array [
     Array [
-      "postcss-import",
+      "<PROJECT_ROOT>/node_modules/postcss-import/index.js",
+      Object {},
     ],
     Array [
-      "postcss-url",
+      "<PROJECT_ROOT>/node_modules/postcss-url/src/index.js",
       Object {
         "url": "rebase",
       },
     ],
     Array [
-      "postcss-mixins",
+      "<PROJECT_ROOT>/node_modules/postcss-mixins/index.js",
       Object {
         "mixinsDir": "./src/styles/mixins",
       },
     ],
     Array [
-      "postcss-advanced-variables",
+      "<PROJECT_ROOT>/node_modules/postcss-advanced-variables/index.js",
       Object {
         "disable": "@mixin, @include, @content, @import",
       },
     ],
     Array [
-      "postcss-preset-env",
+      "<PROJECT_ROOT>/node_modules/postcss-preset-env/index.js",
       Object {
         "autoprefixer": Object {
           "overrideBrowserslist": Array [
@@ -325,10 +341,12 @@ Object {
       },
     ],
     Array [
-      "postcss-color-function",
+      "<PROJECT_ROOT>/node_modules/postcss-color-function/index.js",
+      Object {},
     ],
     Array [
-      "postcss-calc",
+      "<PROJECT_ROOT>/node_modules/postcss-calc/dist/index.js",
+      Object {},
     ],
   ],
 }
@@ -338,29 +356,29 @@ exports[`should pass options.import to postcss-import  1`] = `
 Object {
   "plugins": Array [
     Array [
-      "postcss-import",
+      "<PROJECT_ROOT>/node_modules/postcss-import/index.js",
       "foo",
     ],
     Array [
-      "postcss-url",
+      "<PROJECT_ROOT>/node_modules/postcss-url/src/index.js",
       Object {
         "url": "rebase",
       },
     ],
     Array [
-      "postcss-mixins",
+      "<PROJECT_ROOT>/node_modules/postcss-mixins/index.js",
       Object {
         "mixinsDir": "./src/styles/mixins",
       },
     ],
     Array [
-      "postcss-advanced-variables",
+      "<PROJECT_ROOT>/node_modules/postcss-advanced-variables/index.js",
       Object {
         "disable": "@mixin, @include, @content, @import",
       },
     ],
     Array [
-      "postcss-preset-env",
+      "<PROJECT_ROOT>/node_modules/postcss-preset-env/index.js",
       Object {
         "autoprefixer": Object {
           "overrideBrowserslist": Array [
@@ -384,10 +402,12 @@ Object {
       },
     ],
     Array [
-      "postcss-color-function",
+      "<PROJECT_ROOT>/node_modules/postcss-color-function/index.js",
+      Object {},
     ],
     Array [
-      "postcss-calc",
+      "<PROJECT_ROOT>/node_modules/postcss-calc/dist/index.js",
+      Object {},
     ],
   ],
 }
@@ -397,26 +417,27 @@ exports[`should pass options.mixins to postcss-mixins  1`] = `
 Object {
   "plugins": Array [
     Array [
-      "postcss-import",
+      "<PROJECT_ROOT>/node_modules/postcss-import/index.js",
+      Object {},
     ],
     Array [
-      "postcss-url",
+      "<PROJECT_ROOT>/node_modules/postcss-url/src/index.js",
       Object {
         "url": "rebase",
       },
     ],
     Array [
-      "postcss-mixins",
+      "<PROJECT_ROOT>/node_modules/postcss-mixins/index.js",
       "foo",
     ],
     Array [
-      "postcss-advanced-variables",
+      "<PROJECT_ROOT>/node_modules/postcss-advanced-variables/index.js",
       Object {
         "disable": "@mixin, @include, @content, @import",
       },
     ],
     Array [
-      "postcss-preset-env",
+      "<PROJECT_ROOT>/node_modules/postcss-preset-env/index.js",
       Object {
         "autoprefixer": Object {
           "overrideBrowserslist": Array [
@@ -440,10 +461,12 @@ Object {
       },
     ],
     Array [
-      "postcss-color-function",
+      "<PROJECT_ROOT>/node_modules/postcss-color-function/index.js",
+      Object {},
     ],
     Array [
-      "postcss-calc",
+      "<PROJECT_ROOT>/node_modules/postcss-calc/dist/index.js",
+      Object {},
     ],
   ],
 }
@@ -453,28 +476,29 @@ exports[`should pass options.url to postcss-url 1`] = `
 Object {
   "plugins": Array [
     Array [
-      "postcss-import",
+      "<PROJECT_ROOT>/node_modules/postcss-import/index.js",
+      Object {},
     ],
     Array [
-      "postcss-url",
+      "<PROJECT_ROOT>/node_modules/postcss-url/src/index.js",
       Object {
         "foo": "bar",
       },
     ],
     Array [
-      "postcss-mixins",
+      "<PROJECT_ROOT>/node_modules/postcss-mixins/index.js",
       Object {
         "mixinsDir": "./src/styles/mixins",
       },
     ],
     Array [
-      "postcss-advanced-variables",
+      "<PROJECT_ROOT>/node_modules/postcss-advanced-variables/index.js",
       Object {
         "disable": "@mixin, @include, @content, @import",
       },
     ],
     Array [
-      "postcss-preset-env",
+      "<PROJECT_ROOT>/node_modules/postcss-preset-env/index.js",
       Object {
         "autoprefixer": Object {
           "overrideBrowserslist": Array [
@@ -498,10 +522,12 @@ Object {
       },
     ],
     Array [
-      "postcss-color-function",
+      "<PROJECT_ROOT>/node_modules/postcss-color-function/index.js",
+      Object {},
     ],
     Array [
-      "postcss-calc",
+      "<PROJECT_ROOT>/node_modules/postcss-calc/dist/index.js",
+      Object {},
     ],
   ],
 }

--- a/test/functional.spec.js
+++ b/test/functional.spec.js
@@ -12,7 +12,11 @@ const postcssInstance = (() => {
 
     const instance = postcss();
 
-    plugins.forEach((plugin) => instance.use(plugin));
+    const pluginsEntries = Object.entries(plugins);
+
+    pluginsEntries.forEach(([path, options]) => {
+        instance.use(require(path)(options));
+    });
 
     return instance;
 })();

--- a/test/unit.spec.js
+++ b/test/unit.spec.js
@@ -1,16 +1,10 @@
 'use strict';
 
-const preset = require('..');
+const actualPreset = require('..');
 
-jest.mock('postcss-import', () => (options) => ['postcss-import', options].filter((val) => val));
-jest.mock('postcss-url', () => (options) => ['postcss-url', options].filter((val) => val));
-jest.mock('postcss-advanced-variables', () => (options) => ['postcss-advanced-variables', options].filter((val) => val));
-jest.mock('postcss-mixins', () => (options) => ['postcss-mixins', options].filter((val) => val));
-jest.mock('postcss-calc', () => (options) => ['postcss-calc', options].filter((val) => val));
-jest.mock('postcss-preset-env', () => (options) => ['postcss-preset-env', options].filter((val) => val));
-jest.mock('postcss-color-function', () => (options) => ['postcss-color-function', options].filter((val) => val));
-
-afterEach(jest.resetAllMocks);
+const preset = (options) => ({
+    plugins: Object.entries(actualPreset(options).plugins),
+});
 
 it('should have a good base config', () => {
     expect(preset()).toMatchSnapshot();


### PR DESCRIPTION
Changed the returned plugins structure to a standard one. 
This introduces a breaking change since it has major changes in the returned structure.
Also changed the default options since `import` was `undefined` by default and it should be `{}`. 
